### PR TITLE
Slice opens file each time and gets correct timepoint

### DIFF
--- a/nd2_dask/nd2_reader.py
+++ b/nd2_dask/nd2_reader.py
@@ -177,7 +177,7 @@ def get_layer_list(channels, nd2_func, nd2_data, frame_shape, frame_dtype, n_tim
     layer_list = []
     for channel_name, channel in channel_dict.items():
         add_kwargs = {
-            "scale": [1, 4, 1, 1],
+            "scale": [1, 1, 1, 1],
             "name": channel_name,
             "visible": channel_name == "Alxa 647"
         }

--- a/nd2_dask/nd2_reader.py
+++ b/nd2_dask/nd2_reader.py
@@ -177,7 +177,7 @@ def get_layer_list(channels, nd2_func, nd2_data, frame_shape, frame_dtype, n_tim
     layer_list = []
     for channel_name, channel in channel_dict.items():
         add_kwargs = {
-            "scale": [1, 1, 1, 4],
+            "scale": [1, 4, 1, 1],
             "name": channel_name,
             "visible": channel_name == "Alxa 647"
         }

--- a/nd2_dask/nd2_reader.py
+++ b/nd2_dask/nd2_reader.py
@@ -27,14 +27,15 @@ def get_pims_nd2_vol(nd2_data, c, frame):
     return v
 
 
-def get_nd2reader_nd2_vol(nd2_data, c, frame):
-    nd2_data.default_coords['c']=c
-    nd2_data.bundle_axes = ('z', 'y', 'x')
-    v = nd2_data.get_frame(frame)
-    v = np.array(v)
+def get_nd2reader_nd2_vol(path, c, frame):
+    with ND2Reader(path) as nd2_data:
+        nd2_data.default_coords['c']=c
+        nd2_data.bundle_axes = ('z', 'y', 'x')
+        v = nd2_data.get_frame(frame)
+        v = np.array(v)
     return v    
 
-@napari_hook_implementation(specname="napari_get_reader")
+# @napari_hook_implementation(specname="napari_get_reader")
 def napari_get_pims_reader(path):
     """Returns reader if path is valid .nd2 file, otherwise None
 
@@ -82,7 +83,7 @@ def napari_get_nd2_reader(path):
     return nd2_reader
 
 
-def pims_reader(path):
+def pims_reader(path, max_retries=30):
     """Take a path or list of paths and return a list of LayerData tuples.
 
     Readers are expected to return data as a list of tuples, where each tuple
@@ -104,14 +105,26 @@ def pims_reader(path):
         Both "meta", and "layer_type" are optional. napari will default to
         layer_type=="image" if not provided
     """
-    nd2_data = ND2_Reader(path)
-    channels = [nd2_data.metadata[f"plane_{i}"]["name"] for i in range(0, nd2_data.sizes['c'])]
-    n_timepoints = nd2_data.sizes['t']
-    frame_shape = nd2_data.frame_shape
-    frame_dtype = nd2_data.pixel_type
-    nd2vol = tz.curry(get_pims_nd2_vol)
-    channel_dict = dict(zip(channels, [[] for _ in range(len(channels))]))
-    layer_list = get_layer_list(channels, nd2vol, nd2_data, frame_shape, frame_dtype, n_timepoints)
+
+    tries = 0
+    while tries < max_retries:
+        try:
+            nd2_data = ND2_Reader(path)
+            channels = [nd2_data.metadata[f"plane_{i}"]["name"] for i in range(0, nd2_data.sizes['c'])]
+            n_timepoints = nd2_data.sizes['t']
+            frame_shape = nd2_data.frame_shape
+            frame_dtype = nd2_data.pixel_type
+            nd2vol = tz.curry(get_pims_nd2_vol)
+            channel_dict = dict(zip(channels, [[] for _ in range(len(channels))]))
+            layer_list = get_layer_list(channels, nd2vol, nd2_data, frame_shape, frame_dtype, n_timepoints)
+
+            for (data, _, _) in layer_list:
+                shape = np.asarray(data[0]).shape
+            break
+        except Exception as e:
+            tries += 1
+            if tries > max_retries:
+                raise e
 
     return layer_list
 
@@ -138,14 +151,14 @@ def nd2_reader(path):
         Both "meta", and "layer_type" are optional. napari will default to
         layer_type=="image" if not provided
     """
-    nd2_data = ND2Reader(path)
-    channels = nd2_data.metadata['channels']
-    n_timepoints = nd2_data.sizes['t']
-    z_depth = nd2_data.sizes['z']
-    frame_shape = (z_depth, *nd2_data.frame_shape)
-    frame_dtype = nd2_data._dtype
-    nd2vol = tz.curry(get_nd2reader_nd2_vol)
-    layer_list = get_layer_list(channels, nd2vol, nd2_data, frame_shape, frame_dtype, n_timepoints)
+    with ND2Reader(path) as nd2_data:
+        channels = nd2_data.metadata['channels']
+        n_timepoints = nd2_data.sizes['t']
+        z_depth = nd2_data.sizes['z']
+        frame_shape = (z_depth, *nd2_data.frame_shape)
+        frame_dtype = nd2_data._dtype
+        nd2vol = tz.curry(get_nd2reader_nd2_vol)
+        layer_list = get_layer_list(channels, nd2vol, path, frame_shape, frame_dtype, n_timepoints)
 
     return layer_list
 
@@ -159,7 +172,7 @@ def get_layer_list(channels, nd2_func, nd2_data, frame_shape, frame_dtype, n_tim
             dtype=frame_dtype)
             for  j in range(n_timepoints)]
             )
-        channel_dict[channel] = dask.optimize(arr)
+        channel_dict[channel] = dask.optimize(arr)[0]
 
     layer_list = []
     for channel_name, channel in channel_dict.items():

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 napari-plugin-engine>=0.1.4
 numpy
 nd2reader
+pims-nd2
 dask
 toolz


### PR DESCRIPTION
Due to the unreliability of both ND2Reader and pims ND2_Reader, we rely on nd2reader and open the file each time we need to slice.