### PR TITLE
Read the position and scale metadata from the file

### DIFF
--- a/nd2_dask/nd2_reader.py
+++ b/nd2_dask/nd2_reader.py
@@ -48,21 +48,22 @@ def get_metadata(path):
         x_scale = y_scale = meta['pixel_microns']
         # sampling interval is in ms, we convert to s
         t_scale = meta['experiment']['loops'][0]['sampling_interval'] / 1e3
-        scale = [t_scale, z_scale, y_scale, x_scale]
+        scale = [1, z_scale, -y_scale, -x_scale]
 
         # Translation
         centre_x = raw_meta_seq[b'SLxPictureMetadata'][b'dXPos']
         centre_y = raw_meta_seq[b'SLxPictureMetadata'][b'dYPos']
-        centre_z = raw_meta_seq[b'SLxPictureMetadata'][b'dZPos']
+        # z appears to be interpreted as the origin by Imaris...
+        # not sure this is correct...
+        origin_z = raw_meta_seq[b'SLxPictureMetadata'][b'dZPos']
         size_x = image.sizes['x']
         size_y = image.sizes['y']
-        size_z = image.sizes['z']
         origin_t = 0  # TODO(jni): find a good way to set timepoint offset
         origin = (
             origin_t,
-            centre_z - size_z / 2 * z_scale,
-            centre_y - size_y / 2 * y_scale,
-            centre_x - size_x / 2 * x_scale,
+            origin_z,
+            centre_y + size_y / 2 * y_scale,
+            centre_x + size_x / 2 * x_scale,
         )
     return {'scale': scale, 'translate': origin}
 

--- a/nd2_dask/nd2_reader.py
+++ b/nd2_dask/nd2_reader.py
@@ -31,6 +31,44 @@ VISIBLE = [
     ]
 
 
+def get_metadata(path):
+    with ND2Reader(path) as image:
+        meta = image.metadata
+        raw_meta = image.parser._raw_metadata.image_metadata
+        raw_meta_seq = image.parser._raw_metadata.image_metadata_sequence
+
+        # Scale
+        try:
+            z_scale = (
+                    raw_meta[b'SLxExperiment'][b'ppNextLevelEx']
+                            [b''][b'uLoopPars'][b'dZStep']
+            )
+        except KeyError:
+            z_scale = 4  # TODO(jni): not a good default in general, but needed
+        x_scale = y_scale = meta['pixel_microns']
+        # sampling interval is in ms, we convert to s
+        t_scale = meta['experiment']['loops'][0]['sampling_interval'] / 1e3
+        scale = [t_scale, z_scale, y_scale, x_scale]
+
+        # Translation
+        centre_x = raw_meta_seq[b'SLxPictureMetadata'][b'dXPos']
+        centre_y = raw_meta_seq[b'SLxPictureMetadata'][b'dYPos']
+        centre_z = raw_meta_seq[b'SLxPictureMetadata'][b'dZPos']
+        size_x = image.sizes['x']
+        size_y = image.sizes['y']
+        size_z = image.sizes['z']
+        origin_t = 0  # TODO(jni): find a good way to set timepoint offset
+        origin = (
+            origin_t,
+            centre_z - size_z / 2 * z_scale,
+            centre_y - size_y / 2 * y_scale,
+            centre_x - size_x / 2 * x_scale,
+        )
+    return {'scale': scale, 'translate': origin}
+
+
+
+
 def get_nd2reader_nd2_vol(path, c, frame):
     with ND2Reader(path) as nd2_data:
         nd2_data.default_coords['c']=c
@@ -98,11 +136,11 @@ def nd2_reader(path):
     return layer_list
 
 
-def get_layer_list(channels, nd2_func, nd2_data, frame_shape, frame_dtype, n_timepoints):
+def get_layer_list(channels, nd2_func, path, frame_shape, frame_dtype, n_timepoints):
     channel_dict = dict(zip(channels, [[] for _ in range(len(channels))]))
     for i, channel in enumerate(channels):
         arr = da.stack(
-            [da.from_delayed(delayed(nd2_func(nd2_data, i))(j),
+            [da.from_delayed(delayed(nd2_func(path, i))(j),
             shape=frame_shape,
             dtype=frame_dtype)
             for  j in range(n_timepoints)]
@@ -115,12 +153,13 @@ def get_layer_list(channels, nd2_func, nd2_data, frame_shape, frame_dtype, n_tim
         blending = 'additive' if visible else 'translucent'
         channel_color = list(CHANNEL_COLORS[channel_name])
         color = Colormap([[0, 0, 0],channel_color])
+        meta = get_metadata(path)
         add_kwargs = {
-            "scale": [1, 1, 1, 1],
             "name": channel_name,
             "visible": visible,
             "colormap": color,
-            "blending": blending
+            "blending": blending,
+            **meta
         }
         layer_type = "image"
         layer_list.append(


### PR DESCRIPTION
@Plateletopia gave @AbigailMcGovern and me tracking files from Imaris. To our surprise the coordinates were in the -2000s range. It turns out that nd2reader doesn't surface all of the metadata in the nd2 file. I had to do some deep fishing to figure out where that stuff was stored!

But anyway, this is needed to make the Imaris tracks data correctly align. We should update the trackpy and btrack track data, and even the tracking script, to match this reference frame, but that can be discussed elsewhere.