### PR TITLE
Add napari framework tag for new discovery method

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -41,6 +41,7 @@ setup(
     # setup_requires=['setuptools_scm'],
     classifiers=[
         'Development Status :: 4 - Beta',
+        'Framework :: napari',
         'Intended Audience :: Developers',
         'Topic :: Software Development :: Testing',
         'Programming Language :: Python',


### PR DESCRIPTION
napari no longer searches by name and anyway this never had the napari name in it. :joy: This is now the canonical way to declare oneself a napari plugin.
