### PR TITLE
da.map_blocks and axis handling

### DIFF
--- a/nd2_dask/nd2_reader.py
+++ b/nd2_dask/nd2_reader.py
@@ -105,7 +105,7 @@ def get_metadata(path):
 
 def get_nd2reader_nd2_vol(path, c, frame):
     with ND2Reader(path) as nd2_data:
-        if 'z' in nd2_data.axes:
+        if 'c' in nd2_data.axes:
             nd2_data.default_coords['c'] = c
 
         nd2_data.bundle_axes = [ax for ax in 'zyx' if ax in nd2_data.axes]

--- a/nd2_dask/nd2_reader.py
+++ b/nd2_dask/nd2_reader.py
@@ -105,8 +105,8 @@ def get_metadata(path):
 
 def get_nd2reader_nd2_vol(path, c, frame):
     with ND2Reader(path) as nd2_data:
-        if len(nd2_data.metadata['channels'])>1:
-            nd2_data.default_coords['c']=c
+        if 'z' in nd2_data.axes:
+            nd2_data.default_coords['c'] = c
 
         nd2_data.bundle_axes = [ax for ax in 'zyx' if ax in nd2_data.axes]
         v = nd2_data.get_frame(frame)
@@ -184,7 +184,7 @@ def get_layer_list(channels, nd2_func, path, frame_shape, frame_dtype, n_timepoi
             chunks=da.core.normalize_chunks((1,*frame_shape),(n_timepoints,*frame_shape)),
             new_axis=list(range(1,1+len(frame_shape)))
         )
-        channel_dict[channel] = arr#dask.optimize(arr)[0]
+        channel_dict[channel] = arr
 
     layer_list = []
     for channel_name, channel in channel_dict.items():

--- a/nd2_dask/nd2_reader.py
+++ b/nd2_dask/nd2_reader.py
@@ -71,7 +71,6 @@ def get_metadata(path):
             t_scale = meta['experiment']['loops'][0]['sampling_interval'] / 1e3
         except IndexError:
             t_scale = 1
-
         scale = [1, z_scale, -y_scale, -x_scale]
 
         # Translation
@@ -107,7 +106,6 @@ def get_nd2reader_nd2_vol(path, c, frame):
     with ND2Reader(path) as nd2_data:
         if 'c' in nd2_data.axes:
             nd2_data.default_coords['c'] = c
-
         nd2_data.bundle_axes = [ax for ax in 'zyx' if ax in nd2_data.axes]
         v = nd2_data.get_frame(frame)
         v = np.array(v,ndmin=4)

--- a/nd2_dask/nd2_reader.py
+++ b/nd2_dask/nd2_reader.py
@@ -70,7 +70,7 @@ def get_metadata(path):
         try:
             t_scale = meta['experiment']['loops'][0]['sampling_interval'] / 1e3
         except IndexError:
-            t_scale = 0
+            t_scale = 1
 
         scale = [1, z_scale, -y_scale, -x_scale]
 
@@ -110,7 +110,7 @@ def get_nd2reader_nd2_vol(path, c, frame):
 
         nd2_data.bundle_axes = [ax for ax in 'zyx' if ax in nd2_data.axes]
         v = nd2_data.get_frame(frame)
-        v = np.array(v)[None]
+        v = np.array(v,ndmin=4)
     return v
 
 
@@ -166,7 +166,7 @@ def nd2_reader(path):
         if 'z' in nd2_data.axes:
             frame_shape = (nd2_data.sizes['z'], *nd2_data.frame_shape)
         else:
-            frame_shape = nd2_data.frame_shape
+            frame_shape = (1, *nd2_data.frame_shape)
         frame_dtype = nd2_data._dtype
         nd2vol = tz.curry(get_nd2reader_nd2_vol)
         layer_list = get_layer_list(channels, nd2vol, path, frame_shape, frame_dtype, n_timepoints)


### PR DESCRIPTION
This implements da.map_blocks as per #3, although it still seems slow. Also handles the axes from acquisitions of more types, e.g., tested on data with cyx, czyx, and tzyx axes, which all would have failed previously.